### PR TITLE
fix: service/opencve to only include the webserver

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -11,4 +11,5 @@ spec:
       targetPort: {{ .Values.service.port }} 
       protocol: TCP
   selector:
+    app: webserver
     {{- include "opencve.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Hi, 
with the current helm chart the service/opencve will include `opencve-webserver`
but also `opencve-celery-beat` and `opencve-celery-worker`, which are exposed via ingress.

As result clients requests are also send to the opencve-celery pods and rejected.

This request will only include the `opencve-webserver` as Endpoint in the `service/opencve`.