### PR TITLE
Add configurable redis URI to secret.yaml

### DIFF
--- a/opencve/templates/secret.yaml
+++ b/opencve/templates/secret.yaml
@@ -75,12 +75,12 @@ stringData:
 
     ; Ratelimit storage URI
     ; see https://limits.readthedocs.io/en/latest/storage.html
-    {{ if and (.Values.opencve.config.ratelimit_storage_url) (eq Values.redis.eanbled false) }}
+    {{ if and (.Values.opencve.config.ratelimit_storage_url) (eq Values.redis.enabled false) }}
     ratelimit_storage_url = {{ .Values.opencve.config.ratelimit_storage_url }}
     {{ else }}
     ratelimit_storage_url = redis://opencve-redis-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:6379/2
     {{ end }}
-    
+
     [mail]
     ; Choices are 'smtp' or 'sendmail'
     email_adapter = {{ .Values.opencve.mail.email_adapter }}

--- a/opencve/templates/secret.yaml
+++ b/opencve/templates/secret.yaml
@@ -23,9 +23,21 @@ stringData:
     {{ end }} 
 
     ; see https://kombu.readthedocs.io/en/latest/userguide/connections.html#connection-urls
+    {{ if and (.Values.opencve.config.celery_broker_url) (eq .Values.redis.enabled false) }}
+    celery_broker_url = {{ .Values.opencve.config.celery_broker_url }}
+    {{ else }}
     celery_broker_url = redis://opencve-redis-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:6379/0
+    {{ end }}
+    {{ if and (.Values.opencve.config.celery_result_backend) (eq .Values.redis.enabled false) }}  
+    celery_result_backend = {{ .Values.opencve.config.celery_result_backend }}
+    {{ else }}
     celery_result_backend = redis://opencve-redis-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:6379/1
+    {{ end }}
+    {{ if and (.Values.opencve.config.celery_lock_url) (eq .Values.redis.enabled false) }}
+    celery_lock_url = {{ .Values.opencve.config.celery_lock_url }}
+    {{ else }}
     celery_lock_url = redis://opencve-redis-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:6379/2
+    {{ end }}
 
     ; Display the static frontpage. If False the user will be redirect to the
     ; vulnerabilitites (CVE) page.
@@ -63,8 +75,12 @@ stringData:
 
     ; Ratelimit storage URI
     ; see https://limits.readthedocs.io/en/latest/storage.html
+    {{ if and (.Values.opencve.config.ratelimit_storage_url) (eq Values.redis.eanbled false) }}
+    ratelimit_storage_url = {{ .Values.opencve.config.ratelimit_storage_url }}
+    {{ else }}
     ratelimit_storage_url = redis://opencve-redis-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:6379/2
-
+    {{ end }}
+    
     [mail]
     ; Choices are 'smtp' or 'sendmail'
     email_adapter = {{ .Values.opencve.mail.email_adapter }}

--- a/opencve/values.yaml
+++ b/opencve/values.yaml
@@ -195,6 +195,13 @@ opencve:
     display_welcome: False
     display_terms: False  
   
+    # Use only if you are using external redis
+    # redis.enabled must be set to false
+    # celery_broker_url:
+    # celery_result_backend:
+    # celery_lock_url:
+    # ratelimit_storage_url: 
+
   livenessProbe:
     enabled: True
     periodSeconds: 30


### PR DESCRIPTION
* Add configurable redis URI to chart if values.redis.enabled is set to false

Hi, this change would allow users to specify an external Redis endpoint, if they would like to use Redis that is not managed by the chart. 