### PR TITLE
the servicename is hardcoded inside the secret. This leads to problem…

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "opencve.fullname" . }}
+  name: opencve-redis-master
   labels:
     {{- include "opencve.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
…s in case the name is not opencve