### PR TITLE
Fix typo in Chart.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -27,7 +27,7 @@ dependencies:
   - name: postgresql
     repository: https://charts.helm.sh/stable
     version: 8.6.4
-    condition: postgrsql.enabled
+    condition: postgresql.enabled
   - name: redis
     repository: https://charts.bitnami.com/bitnami
     version: 17.4.0


### PR DESCRIPTION
Hello,

Fix a typo in the Chart.yaml preventing from disabling the deployment of the postgresql chart